### PR TITLE
Prevent non-CAS workers from registering blobs (#2267)

### DIFF
--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -564,7 +564,9 @@ public final class Worker extends LoggingMain {
   private void addBlobsLocation(List<Digest> digests, String name) {
     while (!backplane.isStopped()) {
       try {
-        backplane.addBlobsLocation(digests, name);
+        if (configs.getWorker().getCapabilities().isCas()) {
+          backplane.addBlobsLocation(digests, name);
+        }
         return;
       } catch (IOException e) {
         Status status = Status.fromThrowable(e);


### PR DESCRIPTION
Primary: @chill389cc 

## Why
We've been running into buildfarm looking for things on exec workers instead of CAS only workers. This addresses that problem

## What
Cherry pick the commit in https://github.com/buildfarm/buildfarm/pull/2267 to our fork of buildfarm.