### PR TITLE
Rebase on 2.14.1

### DIFF
--- a/persistentworkers/src/main/java/persistent/bazel/client/PersistentWorker.java
+++ b/persistentworkers/src/main/java/persistent/bazel/client/PersistentWorker.java
@@ -31,8 +31,6 @@ public class PersistentWorker implements Worker<WorkRequest, WorkResponse> {
 
   private static final Logger logger = Logger.getLogger(PersistentWorker.class.getName());
 
-  public static final String TOOL_INPUT_SUBDIR = "tool_inputs";
-
   @Getter private final WorkerKey key;
   @Getter private final ImmutableList<String> initCmd;
   @Getter private final Path execRoot;
@@ -46,17 +44,20 @@ public class PersistentWorker implements Worker<WorkRequest, WorkResponse> {
 
     Files.createDirectories(execRoot);
 
-    Set<Path> workerFiles = ImmutableSet.copyOf(key.getWorkerFilesWithHashes().keySet());
-    logger.log(
-        Level.FINE,
-        "Starting Worker["
-            + key.getMnemonic()
-            + "]<"
-            + execRoot
-            + ">("
-            + initCmd
-            + ") with files: \n"
-            + workerFiles);
+    final var logLevel = Level.FINE;
+    if (logger.isLoggable(logLevel)){
+      Set<Path> workerFiles = ImmutableSet.copyOf(key.getWorkerFilesWithHashes().keySet());
+      StringBuilder msg = new StringBuilder();
+      msg.append("Starting Worker[");
+      msg.append(key.getMnemonic());
+      msg.append("]<");
+      msg.append(execRoot);
+      msg.append(">(");
+      msg.append(initCmd);
+      msg.append(") with files: \n");
+      msg.append(workerFiles);
+      logger.log(logLevel, msg.toString());
+    }
 
     ProcessWrapper processWrapper = new ProcessWrapper(execRoot, initCmd, key.getEnv());
     this.workerRW = new ProtoWorkerRW(processWrapper);

--- a/persistentworkers/src/main/java/persistent/bazel/client/WorkerSupervisor.java
+++ b/persistentworkers/src/main/java/persistent/bazel/client/WorkerSupervisor.java
@@ -1,9 +1,6 @@
 package persistent.bazel.client;
 
-import com.google.common.hash.HashCode;
-import java.nio.file.Path;
 import java.util.Optional;
-import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.commons.pool2.PooledObject;
@@ -49,32 +46,6 @@ public abstract class WorkerSupervisor extends CommonsSupervisor<WorkerKey, Pers
       return false;
     }
 
-    WorkerKey currentWorkerKey = worker.getKey();
-    boolean filesChanged =
-        !key.getWorkerFilesCombinedHash().equals(currentWorkerKey.getWorkerFilesCombinedHash());
-
-    if (filesChanged) {
-      StringBuilder msg = new StringBuilder();
-      msg.append("Worker can no longer be used, because its files have changed on disk:\n");
-      msg.append(key);
-      TreeSet<Path> files = new TreeSet<>();
-      files.addAll(key.getWorkerFilesWithHashes().keySet());
-      files.addAll(currentWorkerKey.getWorkerFilesWithHashes().keySet());
-      for (Path file : files) {
-        HashCode oldHash = currentWorkerKey.getWorkerFilesWithHashes().get(file);
-        HashCode newHash = key.getWorkerFilesWithHashes().get(file);
-        if (!oldHash.equals(newHash)) {
-          msg.append("\n")
-              .append(file.normalize())
-              .append(": ")
-              .append(oldHash != null ? oldHash : "<none>")
-              .append(" -> ")
-              .append(newHash != null ? newHash : "<none>");
-        }
-      }
-      logger.log(Level.SEVERE, msg.toString());
-    }
-
-    return !filesChanged;
+    return true;
   }
 }

--- a/persistentworkers/src/main/java/persistent/common/CommonsSupervisor.java
+++ b/persistentworkers/src/main/java/persistent/common/CommonsSupervisor.java
@@ -36,18 +36,22 @@ public abstract class CommonsSupervisor<K, V extends Destructable>
   public void destroyObject(K key, PooledObject<V> p) {
     V obj = p.getObject();
 
-    StringBuilder msgBuilder = new StringBuilder();
-    msgBuilder.append("Supervisor.destroyObject() from key:\n");
-    msgBuilder.append(key);
-    msgBuilder.append("\nobj.toString():\n");
-    msgBuilder.append(obj);
-    msgBuilder.append("\nSupervisor.destroyObject() stackTrack:");
-    for (StackTraceElement e : Thread.currentThread().getStackTrace()) {
-      msgBuilder.append("\n\t");
-      msgBuilder.append(e);
-    }
+    var maybeOverriddenLogger = getLogger();
+    final var logLevel = Level.FINE;
+    if (maybeOverriddenLogger.isLoggable(logLevel)) {
+      StringBuilder msgBuilder = new StringBuilder();
+      msgBuilder.append("Supervisor.destroyObject() from key:\n");
+      msgBuilder.append(key);
+      msgBuilder.append("\nobj.toString():\n");
+      msgBuilder.append(obj);
+      msgBuilder.append("\nSupervisor.destroyObject() stackTrack:");
+      for (StackTraceElement e : Thread.currentThread().getStackTrace()) {
+        msgBuilder.append("\n\t");
+        msgBuilder.append(e);
+      }
 
-    getLogger().log(Level.FINE, msgBuilder.toString());
+      maybeOverriddenLogger.log(logLevel, msgBuilder.toString());
+    }
 
     obj.destroy();
   }

--- a/src/main/java/build/buildfarm/worker/persistent/Keymaker.java
+++ b/src/main/java/build/buildfarm/worker/persistent/Keymaker.java
@@ -24,7 +24,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Objects;
 import java.util.SortedMap;
-import persistent.bazel.client.PersistentWorker;
 import persistent.bazel.client.WorkerKey;
 
 /** Much of the logic (hashing) is from Bazel itself (private library/methods, i.e. WorkerKey). */
@@ -52,10 +51,9 @@ public class Keymaker {
             executionName,
             sandboxed,
             cancellable);
-    Path toolsRoot = workRoot.resolve(PersistentWorker.TOOL_INPUT_SUBDIR);
 
     SortedMap<Path, HashCode> hashedTools = workerFilesWithHashes(workerFiles);
-    HashCode combinedToolsHash = workerFilesCombinedHash(toolsRoot, hashedTools);
+    HashCode combinedToolsHash = workerFilesCombinedHash(hashedTools);
 
     return new WorkerKey(
         workerInitCmd,
@@ -99,12 +97,11 @@ public class Keymaker {
   }
 
   // Even though we hash the toolsRoot-resolved path, it doesn't exist yet.
-  private static HashCode workerFilesCombinedHash(
-      Path toolsRoot, SortedMap<Path, HashCode> hashedTools) {
+  private static HashCode workerFilesCombinedHash(SortedMap<Path, HashCode> hashedTools) {
     Hasher hasher = Hashing.sha256().newHasher();
     hashedTools.forEach(
         (relPath, toolHash) -> {
-          hasher.putString(toolsRoot.resolve(relPath).toString(), StandardCharsets.UTF_8);
+          hasher.putString(relPath.toString(), StandardCharsets.UTF_8);
           hasher.putBytes(toolHash.asBytes());
         });
     return hasher.hash();

--- a/src/main/java/build/buildfarm/worker/persistent/ProtoCoordinator.java
+++ b/src/main/java/build/buildfarm/worker/persistent/ProtoCoordinator.java
@@ -15,7 +15,6 @@
 package build.buildfarm.worker.persistent;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static persistent.bazel.client.PersistentWorker.TOOL_INPUT_SUBDIR;
 
 import com.google.devtools.build.lib.worker.WorkerProtocol.WorkRequest;
 import com.google.devtools.build.lib.worker.WorkerProtocol.WorkResponse;
@@ -109,7 +108,7 @@ public class ProtoCoordinator extends WorkCoordinator<RequestCtx, ResponseCtx, C
     synchronized (lock) {
       try {
         // Copy tool inputs as needed
-        Path workToolRoot = key.getExecRoot().resolve(PersistentWorker.TOOL_INPUT_SUBDIR);
+        Path workToolRoot = key.getToolRoot();
         for (Path opToolPath : workerFiles.opToolInputs) {
           Path workToolPath = workerFiles.relativizeInput(workToolRoot, opToolPath);
           if (!Files.exists(workToolPath)) {
@@ -135,7 +134,7 @@ public class ProtoCoordinator extends WorkCoordinator<RequestCtx, ResponseCtx, C
       throws IOException {
     log.log(Level.FINE, "loadToolsIntoWorkerRoot() into: " + workerExecRoot);
 
-    Path toolInputRoot = key.getExecRoot().resolve(TOOL_INPUT_SUBDIR);
+    Path toolInputRoot = key.getToolRoot();
     for (Path relPath : key.getWorkerFilesWithHashes().keySet()) {
       Path toolInputPath = toolInputRoot.resolve(relPath);
       Path execRootPath = workerExecRoot.resolve(relPath);

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -510,7 +510,9 @@ public final class Worker extends LoggingMain {
   private void addBlobsLocation(List<Digest> digests, String name) {
     while (!backplane.isStopped()) {
       try {
-        backplane.addBlobsLocation(digests, name);
+        if (configs.getWorker().getCapabilities().isCas()) {
+          backplane.addBlobsLocation(digests, name);
+        }
         return;
       } catch (IOException e) {
         Status status = Status.fromThrowable(e);

--- a/src/test/java/build/buildfarm/worker/persistent/ProtoCoordinatorTest.java
+++ b/src/test/java/build/buildfarm/worker/persistent/ProtoCoordinatorTest.java
@@ -34,7 +34,6 @@ import java.util.Set;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import persistent.bazel.client.PersistentWorker;
 import persistent.bazel.client.WorkerKey;
 
 @RunWith(JUnit4.class)
@@ -102,10 +101,11 @@ public class ProtoCoordinatorTest {
     WorkerKey key = makeWorkerKey(ctx, workerFiles, fsRoot.resolve("workRootsDir"));
 
     Path workRoot = key.getExecRoot();
-    Path toolsRoot = workRoot.resolve(PersistentWorker.TOOL_INPUT_SUBDIR);
+    Path toolsRoot = key.getToolRoot();
 
-    // Assert: all Tools are copied into "/workRootsDir/*/tool_inputs"
+    // Assert: all Tools are copied into "/workRootsDir/*/<tool_inputs_hash>"
     assertThat(toolsRoot.toString()).startsWith(workRoot.toString());
+    assertThat(toolsRoot.toString()).endsWith(key.getWorkerFilesCombinedHash().toString());
     pc.copyToolInputsIntoWorkerToolRoot(key, workerFiles);
 
     assertThat(Files.exists(workRoot)).isTrue();


### PR DESCRIPTION
Add the remote persistent worker fix and the exec-workers-as-cas-workers fix to the lucid branch, and move the lucid branch back to 2.15.0.

Ignore the branch name, this is rebasing on to 2.14.1, not 2.14.0. I ran `git rebase --onto 4c539f6655e70b571f0604a31f8a15a8fb0d5d99 HEAD^^` to get this branch, and 4c539f6655e70b571f0604a31f8a15a8fb0d5d99 is the last commit on 2.14.1 as you can see [here](https://github.com/buildfarm/buildfarm/commits/2.14.1/).