### PR TITLE
Fix buildfarm persistent workers

### DIFF
--- a/persistentworkers/src/main/java/persistent/bazel/client/PersistentWorker.java
+++ b/persistentworkers/src/main/java/persistent/bazel/client/PersistentWorker.java
@@ -77,6 +77,9 @@ public class PersistentWorker implements Worker<WorkRequest, WorkResponse> {
       response = workerRW.waitAndRead();
 
       logIfBadResponse(response);
+    } catch (InterruptedException e) {
+      logger.severe("Interrupted during doWork: " + e.getMessage());
+      Thread.currentThread().interrupt();
     } catch (IOException e) {
       e.printStackTrace();
       logger.severe("IO Failing with : " + e.getMessage());

--- a/persistentworkers/src/main/java/persistent/common/CommonsObjPool.java
+++ b/persistentworkers/src/main/java/persistent/common/CommonsObjPool.java
@@ -19,4 +19,8 @@ public abstract class CommonsObjPool<K, V> extends GenericKeyedObjectPool<K, V>
   public void release(K key, V obj) {
     this.returnObject(key, obj);
   }
+
+  public void invalidate(K key, V obj) throws Exception {
+    this.invalidateObject(key, obj);
+  }
 }

--- a/persistentworkers/src/main/java/persistent/common/CommonsPool.java
+++ b/persistentworkers/src/main/java/persistent/common/CommonsPool.java
@@ -1,6 +1,7 @@
 package persistent.common;
 
 import java.io.IOException;
+import java.util.NoSuchElementException;
 import org.apache.commons.pool2.BaseKeyedPooledObjectFactory;
 import org.apache.commons.pool2.impl.GenericKeyedObjectPoolConfig;
 
@@ -21,6 +22,9 @@ public class CommonsPool<K, V> extends CommonsObjPool<K, V> {
       return super.borrowObject(key);
     } catch (IOException | InterruptedException checkedException) {
       throw checkedException;
+    } catch (NoSuchElementException e) {
+      // Thrown when maxWait expires and no worker is available
+      throw new IOException("Timed out waiting for a persistent worker from the pool", e);
     } catch (Throwable t) {
       throw new RuntimeException("unexpected@<borrowObject>", t);
     }

--- a/persistentworkers/src/main/java/persistent/common/Coordinator.java
+++ b/persistentworkers/src/main/java/persistent/common/Coordinator.java
@@ -31,13 +31,23 @@ public abstract class Coordinator<
 
   public CO runRequest(K workerKey, CI reqWithCtx) throws Exception {
     W worker = workerPool.obtain(workerKey);
+    try {
+      I request = preWorkInit(workerKey, reqWithCtx, worker);
+      O workResponse = worker.doWork(request);
+      CO responseAfterCleanup = postWorkCleanup(workResponse, worker, reqWithCtx);
 
-    I request = preWorkInit(workerKey, reqWithCtx, worker);
-    O workResponse = worker.doWork(request);
-    CO responseAfterCLeanup = postWorkCleanup(workResponse, worker, reqWithCtx);
-
-    workerPool.release(workerKey, worker);
-    return responseAfterCLeanup;
+      workerPool.release(workerKey, worker);
+      return responseAfterCleanup;
+    } catch (Exception e) {
+      try {
+        workerPool.invalidate(workerKey, worker);
+      } catch (Exception invalidateEx) {
+        // Worker may have already been invalidated by timeout handler.
+        // Ensure the process is killed as a fallback.
+        worker.destroy();
+      }
+      throw e;
+    }
   }
 
   public abstract I preWorkInit(K workerKey, CI request, W worker) throws IOException;

--- a/persistentworkers/src/main/java/persistent/common/MapPool.java
+++ b/persistentworkers/src/main/java/persistent/common/MapPool.java
@@ -3,7 +3,7 @@ package persistent.common;
 import java.util.HashMap;
 import java.util.function.Function;
 
-public class MapPool<K, V> implements ObjectPool<K, V> {
+public class MapPool<K, V extends Destructable> implements ObjectPool<K, V> {
   private final HashMap<K, V> map;
 
   private final Function<K, V> objFactory;
@@ -24,5 +24,11 @@ public class MapPool<K, V> implements ObjectPool<K, V> {
   @Override
   public void release(K key, V obj) {
     map.put(key, obj);
+  }
+
+  @Override
+  public void invalidate(K key, V obj) {
+    map.remove(key);
+    obj.destroy();
   }
 }

--- a/persistentworkers/src/main/java/persistent/common/ObjectPool.java
+++ b/persistentworkers/src/main/java/persistent/common/ObjectPool.java
@@ -4,4 +4,10 @@ public interface ObjectPool<K, V> {
   V obtain(K key) throws Exception;
 
   void release(K key, V obj);
+
+  /**
+   * Invalidates an object, destroying it and freeing its slot in the pool. Use this instead of
+   * {@link #release} when the object is in a bad state and should not be reused.
+   */
+  void invalidate(K key, V obj) throws Exception;
 }


### PR DESCRIPTION
  ## Summary                                                                                                                                                                            
   
  Fixes resource management for persistent workers when errors occur during work execution.                                                                                             

  Previously, if a worker encountered an error (IO failure, interruption, etc.), it would still be returned to the pool and potentially reused in a bad state. This could cause
  cascading failures or resource leaks.

  **Key changes:**
  - Add `invalidate()` method to `ObjectPool` interface for destroying workers that are in a bad state
  - Wrap work execution in `Coordinator.runRequest()` with try-catch to invalidate (rather than release) workers on failure
  - Add proper `InterruptedException` handling in `PersistentWorker.doWork()` that preserves interrupt status
  - Handle `NoSuchElementException` in `CommonsPool.borrowObject()` when pool timeout expires, wrapping it in a descriptive `IOException`

## Test Plan
`bazel test //...` in the buildfarm directory passes
Ran the cluster locally via the instructions in `lucid/internal`. Checked the following things:
* all the containers correctly start (server, cas, worker)
* I can run builds against the local cluster
* After manually killing persistent workers, checked the logs for evidence it was invalidated.

I thought about trying to replicate the state we were running into (pushing an action that times out and trying to trigger that state). I think this is good enough as is though. 

